### PR TITLE
Fix api5:getAllUsers.php

### DIFF
--- a/vapi/api5/getAllUsers.php
+++ b/vapi/api5/getAllUsers.php
@@ -19,7 +19,7 @@ if($requestAuth->isHeaderSet())
         
         $result2 = mysqli_query($dbconn,"SELECT id,username,name,address,mobileno from api5users");
         
-        while($row=$result->fetch_assoc())
+        while($row=$result2->fetch_assoc())
         {
             $r[]=$row;
         }


### PR DESCRIPTION
Hi,

While making request to getAllUsers.php, it only returns data of single user instead of all users.

Below change should fix it.

api5/getAllUsers.php :: Line 22: 

`while($row=$result->fetch_assoc())` changed to `while($row=$result2->fetch_assoc())`